### PR TITLE
dependency update works

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,13 @@
-CHARTS := $(shell find . -type d -maxdepth 1 -name '[[:alnum:]]*' | tr '\n' ' ' | sed 's:./::g' )
-DEP_CHARTS := $(shell find . -path '*/requirements.yaml' | tr '\n' ' ' | sed -E 's:\./|/requirements\.yaml::g' )
+CHARTS := $(shell find . -path '*/Chart.yaml' | tr '\n' ' ' | sed -E 's:\./|/Chart\.yaml::g')
+DEP_CHARTS := $(shell find . -path '*/requirements.yaml' | tr '\n' ' ' |  sed -E 's:\./|/requirements\.yaml::g')
 
 .PHONY: clean all package makepath copy index sync acl dependency-update
 all: package makepath copy index sync
 
-dependency-update: ; $(foreach chart,$(DEP_CHARTS),(helm dependency update $(chart)) &&) :
+dependency-update:
+	helm init -c
+	helm repo add atlas http://atlas.cnct.io
+	$(foreach chart,$(DEP_CHARTS),(helm dependency update --debug $(chart); echo $?) && ) :
 
 package: dependency-update ; $(foreach chart,$(CHARTS),(helm package $(chart) --save=false) &&) :
 

--- a/kafka/charts/.gitignore
+++ b/kafka/charts/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore


### PR DESCRIPTION
add helm init/repo add so we can find dependencies in our own
helm repo
modify Charts cmd line find operation to be more robust against the
creation of future valid directories
force creation of almost empty kafka/charts directory to work around
bug in helm alpha.5.  helm beta.1 will create this directory if not
present so no bug filed