### PR TITLE
Remove explicit namespaces from cluster-monitoring resources as helm no

### DIFF
--- a/cluster-monitoring/templates/grafana_service.yaml
+++ b/cluster-monitoring/templates/grafana_service.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: monitoring-grafana
-  namespace: kube-system
   labels:
     kubernetes.io/cluster-service: "true"
     kubernetes.io/name: "Grafana"

--- a/cluster-monitoring/templates/heapster_deployment.yaml
+++ b/cluster-monitoring/templates/heapster_deployment.yaml
@@ -2,7 +2,6 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: heapster-{{.Values.heapster_version}}
-  namespace: kube-system
   labels:
     k8s-app: heapster
     kubernetes.io/cluster-service: "true"

--- a/cluster-monitoring/templates/heapster_service.yaml
+++ b/cluster-monitoring/templates/heapster_service.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: heapster
-  namespace: kube-system
   labels:
     kubernetes.io/cluster-service: "true"
     kubernetes.io/name: "Heapster"

--- a/cluster-monitoring/templates/influx_deployment.yaml
+++ b/cluster-monitoring/templates/influx_deployment.yaml
@@ -2,7 +2,6 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: monitoring-influxdb-grafana-v2
-  namespace: kube-system
   labels:
     k8s-app: influxGrafana
     version: {{.Values.grafana_version}}
@@ -58,7 +57,7 @@ spec:
             - name: GF_AUTH_ANONYMOUS_ORG_ROLE
               value: Admin
             - name: GF_SERVER_ROOT_URL
-              value: /api/v1/proxy/namespaces/kube-system/services/monitoring-grafana/
+              value: /api/v1/proxy/services/monitoring-grafana/
           volumeMounts:
           - name: grafana-persistent-storage
             mountPath: /var

--- a/cluster-monitoring/templates/influx_service.yaml
+++ b/cluster-monitoring/templates/influx_service.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: monitoring-influxdb
-  namespace: kube-system
   labels:
     kubernetes.io/cluster-service: "true"
     kubernetes.io/name: "InfluxDB"

--- a/heapster/templates/deployment.yaml
+++ b/heapster/templates/deployment.yaml
@@ -3,7 +3,6 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: heapster-standalone
-  namespace: kube-system
   labels:
     k8s-app: {{.Values.app_name}}
     kubernetes.io/cluster-service: "true"

--- a/kubedns/templates/kubedns.yaml
+++ b/kubedns/templates/kubedns.yaml
@@ -7,7 +7,6 @@ metadata:
     kubernetes.io/cluster-service: "true"
     version: {{.Values.version}}
   name: {{.Values.k8sapp}}
-  namespace: kube-system
 spec:
   replicas: {{.Values.replicas}}
   selector:


### PR DESCRIPTION
longer supports them.