### PR TITLE
removed namespace from heapster and kubedns services

### DIFF
--- a/heapster/templates/service.yaml
+++ b/heapster/templates/service.yaml
@@ -3,7 +3,6 @@ kind: Service
 apiVersion: v1
 metadata:
   name: {{.Values.app_name}}
-  namespace: kube-system
   labels:
     kubernetes.io/cluster-service: "true"
     kubernetes.io/name: "{{.Values.app_name}}"

--- a/kubedns/templates/kubedns.yaml
+++ b/kubedns/templates/kubedns.yaml
@@ -107,7 +107,6 @@ metadata:
     kubernetes.io/cluster-service: "true"
     kubernetes.io/name: "KubeDNS"
   name: {{.Values.k8sapp}}
-  namespace: kube-system
 spec:
   ports:
   - name: dns


### PR DESCRIPTION
Namespace was removed from pod templates but not services so services could not find pods. 