### PR TITLE
Add grafana chart for k2 monitoring.

### DIFF
--- a/grafana/Chart.yaml
+++ b/grafana/Chart.yaml
@@ -1,0 +1,3 @@
+description: A Helm chart for Grafana
+name: grafana
+version: 0.1.0

--- a/grafana/templates/_helpers.tpl
+++ b/grafana/templates/_helpers.tpl
@@ -1,0 +1,4 @@
+{{define "fullname"}}
+{{- $name := default "grafana" .Values.nameOverride -}}
+{{printf "%s-%s" .Release.Name $name | trunc 24 -}}
+{{end}}

--- a/grafana/templates/deployment.yaml
+++ b/grafana/templates/deployment.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{template "fullname" .}}
+  labels:
+    heritage: {{.Release.Service | quote}}
+    release: {{.Release.Name | quote}}
+    chart: "{{.Chart.Name}}-{{.Chart.Version}}"
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: {{template "fullname" .}}
+        release: {{.Release.Name | quote}}
+    spec:
+      containers:
+      - name: grafana
+        image: "{{.Values.imageName}}:{{default "latest" .Values.imageTag}}"
+        imagePullPolicy: {{default "Always" .Values.pullPolicy}}
+        env:
+          - name: GF_SECURITY_ADMIN_USER
+            value: "{{.Values.adminUser}}"
+          - name: GF_SECURITY_ADMIN_PASSWORD
+            value: "{{.Values.adminPassword}}"
+        ports:
+        - containerPort: 3000
+        resources:
+          requests:
+            cpu: {{default "100m" .Values.Cpu}}
+            memory: {{default "100M" .Values.Memory}}
+        volumeMounts:
+        - mountPath: /data
+          name: storage-volume
+      volumes:
+        - name: storage-volume
+          persistentVolumeClaim:
+            claimName: {{template "fullname" .}}

--- a/grafana/templates/pvc.yaml
+++ b/grafana/templates/pvc.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.persistence.enabled }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{template "fullname" .}}
+  annotations:
+    volume.alpha.kubernetes.io/storage-class: {{ .Values.persistence.storageClass | quote }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+{{- end }}

--- a/grafana/templates/service.yaml
+++ b/grafana/templates/service.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  ports:
+  - name: http
+    port: 80
+    targetPort: 3000
+    protocol: TCP
+    nodePort: 30320
+  selector:
+    app: {{ template "fullname" . }}
+  type: LoadBalancer
+

--- a/grafana/values.yaml
+++ b/grafana/values.yaml
@@ -1,0 +1,11 @@
+---
+imageName: "grafana/grafana"
+adminUser: "admin"
+adminPassword: "admin"
+
+# Persist data to a persitent volume
+persistence:
+  enabled: true
+  storageClass: generic
+  accessMode: ReadWriteOnce
+  size: "1Gi"


### PR DESCRIPTION
This was mostly copied from kubernetes contrib. Once we get our changes into the stable kubernetes chart repo (http://storage.googleapis.com/kubernetes-charts), we probably should remove this.