### PR TITLE
converted logging petsets to statefulsets

### DIFF
--- a/elasticsearch/README.md
+++ b/elasticsearch/README.md
@@ -1,3 +1,3 @@
 ## ElasticSearch Cluster Chart for Kubernetes
 
-Both master pods and data pods are PetSets. 
+Both master pods and data pods are StatefulSets. 

--- a/elasticsearch/templates/es.yaml
+++ b/elasticsearch/templates/es.yaml
@@ -31,8 +31,8 @@ spec:
   selector:
     app: {{.Values.name}}
 ---
-apiVersion: apps/v1alpha1
-kind: PetSet
+apiVersion: apps/v1beta1
+kind: StatefulSet
 metadata:
   name: {{.Values.master_name}}
 spec:
@@ -44,7 +44,6 @@ spec:
         app: {{.Values.name}}
         name: {{.Values.master_name}}
       annotations:
-        pod.alpha.kubernetes.io/initialized: "true"
         pod.alpha.kubernetes.io/init-containers: '[
             {
                 "name": "max-map-count-set",
@@ -99,7 +98,7 @@ spec:
           mountPath: /usr/share/elasticsearch/data
       volumes:
       - name: hostproc
-        hostPath: 
+        hostPath:
           path: /proc
   volumeClaimTemplates:
   - metadata:
@@ -112,8 +111,8 @@ spec:
         requests:
           storage: {{.Values.master_volume_storage}}
 ---
-apiVersion: apps/v1alpha1
-kind: PetSet
+apiVersion: apps/v1beta1
+kind: StatefulSet
 metadata:
   name: {{.Values.data_name}}
 spec:
@@ -125,7 +124,6 @@ spec:
         app: {{.Values.name}}
         name: {{.Values.data_name}}
       annotations:
-        pod.alpha.kubernetes.io/initialized: "true"
         pod.alpha.kubernetes.io/init-containers: '[
             {
                 "name": "max-map-count-set",
@@ -182,7 +180,7 @@ spec:
           mountPath: /usr/share/elasticsearch/data
       volumes:
       - name: hostproc
-        hostPath: 
+        hostPath:
           path: /proc
   volumeClaimTemplates:
   - metadata:

--- a/elasticsearch/values.yaml
+++ b/elasticsearch/values.yaml
@@ -6,18 +6,18 @@
 #Services
 image: quay.io/samsung_cnct/elasticsearch:0.1
 name: elasticsearch
-port: 9200 
+port: 9200
 port_name: http
 port_selector: elasticsearch-data
 cluster_name: elasticsearch-cluster
 cluster_port: 9300
 cluster_port_name: cluster-comms
 
-#Master PetSet
+#Master StatefulSet
 master_name: elasticsearch-master
-# master_replicas: if changing this value, please also update the 
-# elasticsearch configuration file quorum settings in the 
-# samsung_cnct/elasticsearch image. This value should not be altered 
+# master_replicas: if changing this value, please also update the
+# elasticsearch configuration file quorum settings in the
+# samsung_cnct/elasticsearch image. This value should not be altered
 # when running in production
 master_replicas: 3
 master_imagePullPolicy: Always
@@ -25,19 +25,19 @@ master_cpu_limits: 500m
 master_cpu_requests: 500m
 master_memory_limits: 4Gi
 master_memory_requests: 4Gi
-# master_volume_storage: set to small so when exploring with this the 
+# master_volume_storage: set to small so when exploring with this the
 # user doesn't accidentally create very large disks
 master_volume_storage: 20Gi
-# Xms & Xmx: must be the same 
+# Xms & Xmx: must be the same
 # should be ~75% of total memory allocation
 master_Xms_Xmx: 3g
 
-#Cluster PetSet
+#Cluster StatefulSet
 data_name: elasticsearch-data
-# data_replicas: This can be changed at will for scaling purposes 
+# data_replicas: This can be changed at will for scaling purposes
 # either in this chart or at the command line during production
 data_replicas: 3
-# resource notes:  datanodes are pretty heavy.  
+# resource notes:  datanodes are pretty heavy.
 # These should be modified up for a real production setting
 # recommendation is two cores and 20GB of memory for the containers
 data_cpu_limits: 500m
@@ -45,6 +45,6 @@ data_memory_limits: 4Gi
 data_cpu_requests: 500m
 data_memory_requests: 4Gi
 data_volume_storage: 20Gi
-# Xms & Xmx: must be the same 
+# Xms & Xmx: must be the same
 # should be ~75% of total memory allocation
 data_Xms_Xmx: 3g

--- a/kafka/Chart.yaml
+++ b/kafka/Chart.yaml
@@ -1,4 +1,4 @@
-description: Deploy Kafka as a petset
+description: Deploy Kafka as a StatefulSet
 name: kafka
 version: 0.1.0
 keywords: [kafka, java]

--- a/kafka/templates/kafka.yaml
+++ b/kafka/templates/kafka.yaml
@@ -1,4 +1,4 @@
-# A headless service to create DNS records for kafka PetSet
+# A headless service to create DNS records for kafka StatefulSet
 apiVersion: v1
 kind: Service
 metadata:
@@ -15,9 +15,9 @@ spec:
   selector:
     app: {{.Values.name}}
 ---
-# kafka PetSet
-apiVersion: apps/v1alpha1
-kind: PetSet
+# kafka StatefulSet
+apiVersion: apps/v1beta1
+kind: StatefulSet
 metadata:
   name: {{.Values.name}}
 spec:
@@ -27,8 +27,6 @@ spec:
     metadata:
       labels:
         app: {{.Values.name}}
-      annotations:
-        pod.alpha.kubernetes.io/initialized: "true"
     spec:
       containers:
       - name: {{.Values.name}}
@@ -119,4 +117,3 @@ spec:
     name: metrics
   selector:
     app: {{.Values.name}}-monitor
-  

--- a/zookeeper/Chart.yaml
+++ b/zookeeper/Chart.yaml
@@ -1,4 +1,4 @@
-description: ZooKeeper petset chart
+description: ZooKeeper StatefulSet chart
 name: zookeeper
 version: 0.1.0
 keywords: [zookeeper, java]

--- a/zookeeper/templates/zookeeper.yaml
+++ b/zookeeper/templates/zookeeper.yaml
@@ -17,8 +17,8 @@ spec:
   selector:
     app: {{.Values.name}}
 ---
-apiVersion: apps/v1alpha1
-kind: PetSet
+apiVersion: apps/v1beta1
+kind: StatefulSet
 metadata:
   name: {{.Values.name}}
 spec:
@@ -29,7 +29,6 @@ spec:
       labels:
         app: {{.Values.name}}
       annotations:
-        pod.alpha.kubernetes.io/initialized: "true"
         pod.alpha.kubernetes.io/init-containers: '[
             {
                 "name": "install",


### PR DESCRIPTION
Converted all petsets involved in logging solution to statefulsets and reset apiVersion from apps/v1alpha1 to apps/v1beta1. also  removed debug hook annotation pod.alpha.kubernetes.io/initialized since it now redundant.  This logging pipeline will now work with k8s versions > 1.5