### PR TITLE
updated values to include logrotate-sidecar

### DIFF
--- a/daemon-fluentd/templates/fluentd.yaml
+++ b/daemon-fluentd/templates/fluentd.yaml
@@ -13,8 +13,8 @@ spec:
         kubernetes.io/cluster-service: "true"
     spec:
       containers:
-      - name: {{.Values.container_name}}
-        image: {{.Values.image}}
+      - name: {{.Values.fluentd_container_name}}
+        image: {{.Values.fluentd_image}}
         resources:
           limits:
             memory: {{.Values.memory_limits}}
@@ -27,6 +27,14 @@ spec:
         - name: varlibdockercontainers
           mountPath: /var/lib/docker/containers
           readOnly: true
+      - name: {{.Values.sidecar_container_name}}
+        image: {{.Values.logrotate_image}}
+        env:
+          - name: ALLAPPLICATIONLOGS
+            value: '/var/log/containers'
+        volumeMounts:
+        - name: varlog
+          mountPath: /var/log/
       terminationGracePeriodSeconds: 30
       volumes:
       - name: varlog

--- a/daemon-fluentd/values.yaml
+++ b/daemon-fluentd/values.yaml
@@ -3,8 +3,10 @@
 name: fluentd-daemon
 app: log-app
 k8s: fluentd-logging
-container_name: fluentd-kafka
-image: quay.io/samsung_cnct/fluentd_daemonset
+fluentd_container_name: fluentd-kafka
+fluentd_image: quay.io/samsung_cnct/fluentd_daemonset
 memory_limits: 200Mi
 cpu_requests: 100m
 memory_requests: 200Mi
+sidecar_container_name: logrotate-sidecar
+logrotate_image: quay.io/samsung_cnct/logrotate


### PR DESCRIPTION
fluentd-daemonset now includes a logrotate sidecar to handle rotation of named log files