### PR TITLE
reverted namespace for es service to kube-system

### DIFF
--- a/kibana/Chart.yaml
+++ b/kibana/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Kibana Helm chart for Kubernetes
 name: kibana
-version: 0.1.3
+version: 0.1.4
 keywords: [kibana, data]
 maintainers:
  - name: Leah Petersen

--- a/kibana/values.yaml
+++ b/kibana/values.yaml
@@ -12,7 +12,7 @@ image: docker.elastic.co/kibana/kibana:5.4.2
 cpu_limit: 100m
 cpu_requests: 100m
 env_name: ELASTICSEARCH_URL
-env_value: http://elasticsearch.kube-logging:9200
+env_value: http://elasticsearch.kube-system:9200
 container_port: 5601
 tolerations:
  # - key: taintKey


### PR DESCRIPTION
Had to put es in kube-system to use ingress which didn't accept a "." in the service name. 